### PR TITLE
Add support for pref-specified locations to pull android libs

### DIFF
--- a/data/SymbolicateModule.jsm
+++ b/data/SymbolicateModule.jsm
@@ -1,3 +1,5 @@
+/* -*- Mode: js2; indent-tabs-mode: nil -*- */
+
 var EXPORTED_SYMBOLS = ["symbolicate"];
 
 var Cc = Components.classes;
@@ -6,19 +8,36 @@ var Ci = Components.interfaces;
 // Change this in main as well where we default init the pref
 const DEFAULT_SYMBOLICATION_URL = "http://symbolapi.mozilla.org/";
 
+function getPref(prefName, defaultValue) {
+  var value = defaultValue;
+  try {
+      var prefs = Cc["@mozilla.org/preferences-service;1"]
+                  .getService(Ci.nsIPrefService).getBranch("profiler.");
+      value = prefs.getCharPref(prefName);
+  } catch (e) {
+      value = defaultValue;
+  }
+  return value;
+}
+
 var sWorker = null;
 function getWorker() {
   if (!sWorker) {
     sWorker = new ChromeWorker("SymbolicateWorker.js");
     var hh = Cc["@mozilla.org/network/protocol;1?name=http"].getService(Ci.nsIHttpProtocolHandler);
     var abi = Cc["@mozilla.org/xre/app-info;1"].getService(Ci.nsIXULRuntime).XPCOMABI;
-    sWorker.postMessage({ platform: hh["platform"], abi: abi });
+    sWorker.postMessage({
+        platform: hh["platform"],
+        abi: abi,
+        androidLibsPrefix: getPref("androidLibsHostPath", "/tmp"),
+        fennecLibsPrefix: getPref("fennecLibsHostPath", "/tmp")
+    });
   }
   return sWorker;
 }
 
 var sProfileID = 0;
-function symbolicate(profile, targetPlatform, sharedLibraries, progressCallback, finishCallback) {
+function symbolicate(profile, targetPlatform, sharedLibraries, progressCallback, finishCallback, hwid) {
   var worker = getWorker();
 
   var id = sProfileID++;
@@ -42,14 +61,12 @@ function symbolicate(profile, targetPlatform, sharedLibraries, progressCallback,
     }
   });
 
-  var uri = "";
-  try {
-      var prefs = Cc["@mozilla.org/preferences-service;1"]
-                  .getService(Ci.nsIPrefService).getBranch("profiler.");
-      uri = prefs.getCharPref("symbolicationUrl");
-  } catch (e) {
-      uri = DEFAULT_SYMBOLICATION_URL;
-  }
-
-  worker.postMessage({ id: id, profile: profile, targetPlatform: targetPlatform, sharedLibraries: sharedLibraries, uri: uri });
+  var uri = getPref("symbolicationUrl", DEFAULT_SYMBOLICATION_URL);
+  worker.postMessage({ id: id,
+                       profile: profile,
+                       targetPlatform: targetPlatform,
+                       sharedLibraries: sharedLibraries,
+                       uri: uri,
+                       androidHWID: hwid
+                     });
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,3 +1,4 @@
+/* -*- Mode: js2; indent-tabs-mode: nil; -*- */
 /* ***** BEGIN LICENSE BLOCK *****
  * Version: MPL 1.1/GPL 2.0/LGPL 2.1
  *
@@ -52,6 +53,7 @@ let prefs = require("prefs");
 let data = require("self").data;
 let clipboard = require("clipboard");
 let timers = require("timers");
+let file = require("file");
 let tabs;
 
 // For Thunderbird the tabs module is not supported, and will throw if we try
@@ -74,6 +76,8 @@ var panel = null;
 var c = 0;
 var settingsTab = null;
 var settingsTabPort = null;
+
+var gCurrentAndroidHWID = null;
 
 String.prototype.endsWith = function(suffix) {
       return this.indexOf(suffix, this.length - suffix.length) !== -1;
@@ -143,6 +147,8 @@ function sps_startup(force) {
     prefs.default_init_pref_string("profiler.", "symbolicationUrl", DEFAULT_SYMBOLICATION_URL);
     prefs.default_init_pref_string("profiler.", "format", DEFAULT_PROFILE_FORMAT);
     prefs.default_init_pref_string("profiler.", "url", DEFAULT_UI_URL);
+    prefs.default_init_pref_string("profiler.", "androidLibsHostPath", "/tmp");
+    prefs.default_init_pref_string("profiler.", "fennecLibsHostPath", "/tmp");
 
     if (get_ui_url() == OLD_UI_URL) {
         prefs.set_pref_string("profiler.", "url", DEFAULT_UI_URL);
@@ -220,9 +226,46 @@ function get_profile(progress_callback, finish_callback) {
     return;
 }
 
-function adb_pull_libs(progress_callback, finish_callback) {
-    cmdRunnerModule.runCommand("/bin/bash -l -c 'adb shell ls /system/lib | sed \"s;^;/system/lib/;\" && adb shell ls /system/vendor/lib/egl | sed \"s;^;/system/vendor/lib/egl/;\"; adb shell ls /system/b2g  | sed \"s;^;/system/b2g/;\"'", function(r) {
+function adb_get_hwid(callback) {
+    cmdRunnerModule.runCommand("/bin/bash -l -c 'adb devices'", function(r) {
+        var connectedDevices = [];
         var lines = r.split("\n");
+        for (var i = 0; i < lines.length; ++i) {
+            var line = lines[i].trim().split(/\W+/);
+            if (line.length < 2 || line[1] != "device")
+                continue;
+            connectedDevices.push(line[0]);
+        }
+
+        if (connectedDevices.length == 0) {
+            callback(null);
+            return;
+        }
+
+        if (connectedDevices.length != 1) {
+            callback(null);
+            return;
+        }
+
+        var hwid = connectedDevices[0];
+        callback(hwid);
+    });
+}
+
+function adb_pull_libs(progress_callback, finish_callback) {
+    var pathPrefix = prefs.get_pref_string("profiler.", "androidLibsHostPath");
+
+    // paths to pull
+    var libPaths = [ "/system/lib",
+                     "/system/lib/egl",
+                     "/system/lib/hw",
+                     "/system/vendor/lib",
+                     "/system/vendor/lib/egl",
+                     "/system/vendor/lib/hw",
+                     "/system/b2g" ];
+
+    var pullLibs = function(libPath, destDirBasePath, libsList) {
+        var lines = libsList.split("\n");
         var libsToPull = [];
         for (var i = 0; i < lines.length; i++) {
             var line = lines[i].trim();
@@ -230,16 +273,61 @@ function adb_pull_libs(progress_callback, finish_callback) {
             libsToPull.push(line);
         }
         var total = libsToPull.length;
-        for (var i = 0; i < libsToPull.length; i++) {
+
+        var libsPulled = 0;
+        for (var i = 0; i < total; i++) {
             let libName = libsToPull[i];
-            cmdRunnerModule.runCommand("/bin/bash -l -c 'adb pull " + libName + " /tmp'", function(r) {
-                progress_callback({progress: (total-libsToPull.length)/total, action: "Pulled Device library: " + libName});
-                libsToPull.splice(libsToPull.indexOf(libName), 1);
-                dump("Pulled Device library: " + libName + "\n");
-                if (libsToPull.length == 0) {
+            let srcPath = libPath + "/" + libName;
+
+            // this is horrid, but will get the job done; we have to split on "/" so that we can
+            // get the OS-native path separators later
+            var pathArg = libPath.substr(1).split("/");
+            // then we stick the destDirBasePath at the front, and use join.apply() to get the final path
+            pathArg.splice(0, 0, destDirBasePath);
+            let dstPath = file.join.apply(null, pathArg);
+
+            file.mkpath(dstPath);
+
+            if (file.exists(file.join(dstPath, libName))) {
+                progress_callback({progress: libsPulled/total, action: "Skipped already existing library: " + libName});
+                libsPulled++;
+                continue;
+            }
+
+            cmdRunnerModule.runCommand("/bin/bash -l -c 'adb pull " + srcPath + " " + dstPath + "'", function(r) {
+                libsPulled++;
+
+                progress_callback({progress: libsPulled/total, action: "Pulled Device library: " + libName});
+                dump("Pulled Device library: " + libName + " -> " + dstPath + "\n");
+
+                if (libsPulled == total) {
                     progress_callback({progress: 0, action: "Got all libraries"});
                 }
             });
+        }
+
+        // in case we skipped everything
+        if (libsPulled == total) {
+            progress_callback({progress: 0, action: "Got all libraries"});
+        }
+    };
+
+    adb_get_hwid(function(hwid) {
+        if (hwid == null)
+            return;
+
+        var baseDirPath = file.join(pathPrefix, hwid);
+        file.mkpath(baseDirPath);
+
+        dump("HWID " + hwid + "\n");
+
+        for (var i = 0; i < libPaths.length; ++i) {
+            var libPath = libPaths[i];
+            
+            // grab the list of files in this libPath, and process them
+            cmdRunnerModule.runCommand("/bin/bash -l -c 'adb shell ls " + libPath + "'", (function(xLibPath) { return function(r) {
+                pullLibs(xLibPath, baseDirPath, r);
+            }; })(libPath));
         }
     });
 }
@@ -308,6 +396,8 @@ function adb_get_process_info(finish_callback) {
 }
 
 function adb_pull(progress_callback, finish_callback) {
+    var fennecPathPrefix = prefs.get_pref_string("profiler.", "fennecLibsHostPath");
+
     if (progress_callback != null) {
         progress_callback({progress: 0, action: "Check Env: ADB"});
     }
@@ -326,7 +416,7 @@ function adb_pull(progress_callback, finish_callback) {
             adb_get_process_info( function (processInfo) {
                 if (processInfo.error != null) {
                     progress_callback({progress: 0, action: processInfo.error});
-                    return
+                    return;
                 }
                 progress_callback({progress: 0.15, action: "Pulling profile: Send signal to pid: " + processInfo.pid});
                 dump("Dump Profile: " + processInfo.stopCmd + "\n");
@@ -349,19 +439,30 @@ function adb_pull(progress_callback, finish_callback) {
                                 return;
                             }
                             timers.clearInterval(intervalId);
-                            progress_callback({progress: 0, action: "Pulling profile: adb pull"});
+                            progress_callback({progress: 0, action: "Pulling fennec libs and profile: adb pull"});
+
+                            // now pull the fennec libs themselves
                             cmdRunnerModule.runCommand("/bin/bash -l -c 'rm tmp/symbol.apk'", function (r) {});
-                            cmdRunnerModule.runCommand("/bin/bash -l -c 'adb pull " + processInfo.savePath + "/profile_0_" + processInfo.pid + ".txt /tmp/fennec_profile.txt; adb pull /data/app/" + processInfo.pkgName + "-1.apk /tmp/symbol.apk || adb pull /data/app/" + processInfo.pkgName + "-2.apk /tmp/symbol.apk; unzip -o /tmp/symbol.apk -d /tmp'; cp /tmp/lib/armeabi-v7a/libmozglue.so /tmp", function (r) {
-                                progress_callback({progress: 0.6, action: "Pulling profile: reading"});
-                                cmdRunnerModule.runCommand("/bin/bash -l -c 'adb shell rm " + processInfo.savePath + "/profile_0_" + processInfo.pid + ".txt'", function (r) {});
-                                cmdRunnerModule.runCommand("/bin/cat /tmp/fennec_profile.txt", function (r) {
-                                    dump("Got raw profile: " + r.length + "\n");
-                                    progress_callback({progress: 0.7, action: "Parsing"});
-                                    symbolicateModule.symbolicate(r, "Android", null, progress_callback, finish_callback);
-                                    //dump("Profile: '" + r + "'\n");
-                                    //finish_callback(r);
+                            cmdRunnerModule.runCommand(
+                                "/bin/bash -l -c 'adb pull " + processInfo.savePath + "/profile_0_" + processInfo.pid + ".txt /tmp/fennec_profile.txt; " + 
+                                "adb pull /data/app/" + processInfo.pkgName + "-1.apk /tmp/symbol.apk || adb pull /data/app/" + processInfo.pkgName + "-2.apk /tmp/symbol.apk; " +
+                                "unzip -o /tmp/symbol.apk -d \"" + fennecPathPrefix + "\"'; cp \"" + fennecPathPrefix + "\"/lib/armeabi-v7a/libmozglue.so \"" + fennecPathPrefix + "\"",
+                                function (r) {
+                                    progress_callback({progress: 0.6, action: "Pulling profile: reading"});
+                                    adb_get_hwid(function(hwid) {
+                                        if (hwid == null)
+                                            return;
+
+                                        cmdRunnerModule.runCommand("/bin/bash -l -c 'adb shell rm " + processInfo.savePath + "/profile_0_" + processInfo.pid + ".txt'", function (r) {});
+                                        cmdRunnerModule.runCommand("/bin/cat /tmp/fennec_profile.txt", function (r) {
+                                            dump("Got raw profile: " + r.length + "\n");
+                                            progress_callback({progress: 0.7, action: "Parsing"});
+                                            symbolicateModule.symbolicate(r, "Android", null, progress_callback, finish_callback);
+                                            //dump("Profile: '" + r + "'\n");
+                                            //finish_callback(r);
+                                        });
+                                    });
                                 });
-                            });
                         }, 50);
                     });
                 });

--- a/test.sh
+++ b/test.sh
@@ -23,6 +23,12 @@ then
   exit
 fi
 
+if [ -e ~/firefox/firefox ]
+then
+  cfx run --binary ~/firefox/firefox
+  exit
+fi
+
 if [ -e /Users/bgirard/ssd-mozilla/mozilla-central/builds/obj-ff-64gdb/dist/NightlyDebug.app ]
 then
   echo "64 gdb"


### PR DESCRIPTION
This adds support for profiler.androidLibsPrefix and profiler.fennecLibsPrefix prefs.  Android system libs will be pulled to $androidLibsPrefix/$hwid/..., so that those paths can be shared with the debugger and that multiple devices can be used without re-pulling.  fennec's libs are pulled directly into $fennecLibsPrefix, and that's done every time you hit Pull.

They both default to /tmp, mainly because I couldn't find an easy way to get the user's home dir.
