### PR TITLE
Fix a regression

### DIFF
--- a/lib/remote.js
+++ b/lib/remote.js
@@ -39,7 +39,7 @@ const {Cc,Ci,Cu} = require("chrome");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/AddonManager.jsm");
-//Cu.import("resource://gre/modules/devtools/dbg-client.jsm");
+Cu.import("resource://gre/modules/devtools/dbg-client.jsm");
 
 XPCOMUtils.defineLazyGetter(this, "DebuggerServer", function() {
   Cu.import("resource://gre/modules/devtools/dbg-server.jsm");


### PR DESCRIPTION
The import of the debugger client seems to have been inadvertently commented-out in an unrelated patch.
