### PR TITLE
Give the widget a hover state.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1459,7 +1459,7 @@ let FirefoxAppWrapper = {
         spsWidget = require("widget").Widget({
           id: "hello-display",
           label: "Built-in Profiler",
-          content: "Profiler",
+          content: "<p style='cursor:pointer;'>Profiler</p>",
           width: 200,
           panel: panel
         });
@@ -1556,7 +1556,7 @@ let FirefoxAppWrapper = {
       if (this.pb.isActive) {
         addonLabel = "Private Browsing";
       }
-      spsWidget.content = "Profiler: " + addonLabel;
+      spsWidget.content = "<p style='cursor:pointer;'>Profiler: " + addonLabel + "</p>";
       var profilerStatus = {
           profilerFeatures: profilerFeatures, 
           profilerFeaturesPrefs: profilerFeaturesPrefs,


### PR DESCRIPTION
This makes the cursor turn into a pointer when you hover over the widget in the addon bar, so it looks actually clickable.
