### PR TITLE
Fix up fennec libs path + port wonkiness

### DIFF
--- a/data/sps_panel.html
+++ b/data/sps_panel.html
@@ -53,8 +53,9 @@ table {
     <div class="targetPanel" id="divTypeAdbConfig" style="display:none">
       <table width="100%">
 	<tr><td>
-	    Port: <input id="adbPort" value="16000" style="width:100px;"></input><br>
-	    <div class="info">Local port to use.  It will be forwarded to your device's port 6000.</div>
+	    Ports &mdash; Local: <input id="adbPort" value="16000" style="width: 50px;"></input>
+	    Remote: <input id="debugPort" value="6000" style="width: 50px;"></input><br>
+	    <div class="info">Ports to use. The local port will be forwarded to the remote via adb.</div>
 	</td></tr>
 
 	<tr><td>

--- a/data/sps_panel.js
+++ b/data/sps_panel.js
@@ -173,6 +173,7 @@ function adbConnect() {
         systemLibCache: document.getElementById("systemLibCache").value,
         fennecLibCache: document.getElementById("fennecLibCache").value,
         port: document.getElementById("adbPort").value,
+        remotePort: document.getElementById("debugPort").value,
     };
     document.getElementById("adbStatus").innerHTML = "Connecting via adb on port " + options.port + ".";
     self.port.emit("adbconnect", options);

--- a/lib/main.js
+++ b/lib/main.js
@@ -1578,12 +1578,13 @@ let FirefoxAppWrapper = {
       });
       panel.port.on("adbconnect", function(options) {
           var port = options.port;
+          var remotePort = options.remotePort;
           prefs.set_pref_string("profiler.", "androidLibsHostPath", options.systemLibCache);
           prefs.set_pref_string("profiler.", "fennecLibsHostPath", options.fennecLibCache);
           remoteHostInstance.setAdbLibCache(options.systemLibCache, options.fennecLibCache);
           remoteHostInstance.prepareLibs(
             function cb() {
-              remoteHostInstance.forwardPort(port,
+              remoteHostInstance.forwardPort(port, remotePort,
                 function cb() {
                     var options = {
                       hostname: "localhost",

--- a/lib/remoteHost.js
+++ b/lib/remoteHost.js
@@ -239,8 +239,8 @@ RemoteHost.prototype.prepareLibs = function RemoteHost_prepareLibs(cb, error_cb,
   });
 }
 
-RemoteHost.prototype.forwardPort = function RemoteHost_forwardPort(port, cb, error_cb) {
-  cmdRunnerModule.runCommand("/bin/bash -l -c '" + this._adbCommand + " forward tcp:" + port + " tcp:6000 2>&1'", function (r) {
+RemoteHost.prototype.forwardPort = function RemoteHost_forwardPort(port, remotePort, cb, error_cb) {
+  cmdRunnerModule.runCommand("/bin/bash -l -c '" + this._adbCommand + " forward tcp:" + port + " tcp:" + remotePort + " 2>&1'", function (r) {
     if (r.indexOf("error: device not found") >= 0) {
       error_cb({description: r});
     } else if (r.indexOf("error: cannot bind socket") >= 0) {


### PR DESCRIPTION
This pulls the fennec libs to the right location, and lets you specify them separately.  Also defaults the port to 16000 and makes this the "local" port and always uses 6000 for the remote.  Also does a bit of prettification of sps_panel.html.
