### PR TITLE
update installation instructions

### DIFF
--- a/README
+++ b/README
@@ -20,13 +20,13 @@ In order to install this add-on, you need a copy of the add-on SDK.  Please do t
 
 1. `cd /path/to/Gecko-Profiler-Addon`
 2. `git clone https://github.com/mozilla/addon-sdk sdk && cd sdk`
-2. `git checkout 1.12` (the latest SDK version)
-3. `cd packages`
+   `git checkout 1.12` (the latest SDK version)
+   `cd ..`
+3. `mkdir packages && cd packages`
    `git clone https://github.com/erikvold/vold-utils-jplib`
    `git clone https://github.com/erikvold/xulkeys-jplib`
    `git clone https://github.com/voldsoftware/toolbarbutton-jplib.git`
    `cd ..`
-4. `. bin/activate`
-5. `cd ..`
-6. `cfx xpi`
+4. `cd sdk && . bin/activate && cd ..`
+5. `cfx xpi`
 


### PR DESCRIPTION
And also: it's still not possible to install this add-on on linux from addons.mozilla.org. It says "Not available for your platform", but it appears to run fine when I package it from source. (Well, it runs fine on firefox 18 and not firefox 17, but that distinction only matters for a few more days.) You might consider changing the settings on AMO to allow installing to linux.
