### PR TITLE
Update README to check out SDK 1.13.2 instead of 1.12

### DIFF
--- a/README
+++ b/README
@@ -20,7 +20,7 @@ In order to install this add-on, you need a copy of the add-on SDK.  Please do t
 
 1. `cd /path/to/Gecko-Profiler-Addon`
 2. `git clone https://github.com/mozilla/addon-sdk sdk && cd sdk`
-   `git checkout 1.12` (the latest SDK version)
+   `git checkout 1.13.2` (the latest SDK version)
    `cd ..`
 3. `mkdir packages && cd packages`
    `git clone https://github.com/erikvold/vold-utils-jplib`


### PR DESCRIPTION
Some breaking changes in recent Firefox builds have been fixed in SDK 1.13 (and the two point releases based off of it). Using SDK 1.12 against the current Firefox Nightly, you'd get a "tabs.open is undefined" error when you click the "Analyze" button. 

Switching to SDK 1.13.2 no longer throws that error.
