### PR TITLE
Fix browsing for lib directories

### DIFF
--- a/data/sps_panel.js
+++ b/data/sps_panel.js
@@ -139,8 +139,8 @@ self.port.on("change_status", function(val) {
     document.getElementById("lblTargetDesc").textContent = val.profilerTargetDescription;
     document.getElementById("btnToggleActive").textContent = val.runningLabel;
     //document.getElementById("divAdb").style.display = get_feature_pref("adb") ? "" : "none";
-    document.getElementById("systemLibCache").textContent = val.systemLibCache;
-    document.getElementById("fennecLibCache").textContent = val.fennecLibCache;
+    document.getElementById("systemLibCache").value = val.systemLibCache;
+    document.getElementById("fennecLibCache").value = val.fennecLibCache;
 });
 
 function sps_toggle_active() {
@@ -258,12 +258,12 @@ function open_settings() {
 document.getElementById("btnSettings").onclick = open_settings;
 
 function browse_system_lib_folder() {
-    self.port.emit("browselibfolder", document.getElementById("systemLibCache"));
+    self.port.emit("browselibfolder", document.getElementById("systemLibCache").value);
 }
 document.getElementById("btnALibBrowse").onclick = browse_system_lib_folder;
 
 function browse_fennec_lib_folder() {
-    self.port.emit("browselibfolder", document.getElementById("fennecLibCache"));
+    self.port.emit("browselibfolder", document.getElementById("fennecLibCache").value);
 }
 document.getElementById("btnFLibBrowse").onclick = browse_fennec_lib_folder;
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1881,6 +1881,14 @@ let FirefoxAppWrapper = {
           fp.init(window, "Folder to cache mobile system libraries", Ci.nsIFilePicker.modeGetFolder);
           fp.appendFilters(Ci.nsIFilePicker.filterAll);
           fp.filterIndex = 0;
+
+          try {
+              var initialDir = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsILocalFile);
+              initialDir.initWithPath(defaultFolder);
+              fp.displayDirectory = initialDir;
+          } catch (e) {
+          }
+
           var res = fp.show();
           if (res === Ci.nsIFilePicker.returnOK) {
               prefs.set_pref_string("profiler.", "androidLibsHostPath", fp.file.path);


### PR DESCRIPTION
This change fixes a bug where the Android lib inputs are not updated after browsing for a directory. Also, the file picker now defaults to the currently selected directory
