### PR TITLE
Support multiple fennec packages

### DIFF
--- a/data/sps_panel.html
+++ b/data/sps_panel.html
@@ -70,6 +70,13 @@ table {
 	    <div class="info">Where to look for/unpack Fennec libs to.</div>
 	</td></tr>
 
+	<tr><td>
+	    Package:
+	    <select id="fennecPkg">
+		<option value="auto">(auto)</option>
+	    </select>
+	</td></tr>
+
 	<tr><td>&nbsp;</td></tr>
 
 	<tr><td><div id="adbStatus" class="status"></div></td></tr>

--- a/data/sps_panel.js
+++ b/data/sps_panel.js
@@ -190,17 +190,32 @@ self.port.on("show_adb_status", function(val) {
   document.getElementById("adbStatus").textContent = val;
 });
 
+self.port.on("show_packages", function(val) {
+    var pkgs = document.getElementById("fennecPkg");
+    // clear the packages list except "auto"
+    pkgs.options.length = 1;
+    val.forEach(function (val) {
+        var opt = document.createElement("option");
+        opt.text = val;
+        opt.value = val;
+        pkgs.options.add(opt);
+    });
+    pkgs.selectedIndex = pkgs.options.length - 1;
+});
+
 function bugzilla_file_bug() {
     self.port.emit("filebug", "test");
 }
 //document.getElementById("btnFileBug").onclick = bugzilla_file_bug;
 
 function adbConnect() {
+    var pkg = document.getElementById("fennecPkg").value;
     var options = {
         systemLibCache: document.getElementById("systemLibCache").value,
         fennecLibCache: document.getElementById("fennecLibCache").value,
         port: document.getElementById("adbPort").value,
         remotePort: document.getElementById("debugPort").value,
+        pkg: pkg === "auto" ? null : pkg
     };
     document.getElementById("adbStatus").textContent = "Connecting via adb on port " + options.port + ".";
     self.port.emit("adbconnect", options);

--- a/lib/main.js
+++ b/lib/main.js
@@ -1888,7 +1888,7 @@ let FirefoxAppWrapper = {
           prefs.set_pref_string("profiler.", "androidLibsHostPath", options.systemLibCache);
           prefs.set_pref_string("profiler.", "fennecLibsHostPath", options.fennecLibCache);
           remoteHostInstance.setAdbLibCache(options.systemLibCache, options.fennecLibCache);
-          remoteHostInstance.prepareLibs(
+          remoteHostInstance.prepareLibs(options.pkg,
             function cb() {
               remoteHostInstance.forwardPort(port, remotePort,
                 function cb() {
@@ -1899,7 +1899,10 @@ let FirefoxAppWrapper = {
                       platform: "Android",
                       hardwareID: remoteHostInstance.getHardwareID()
                     };
-                    panel.port.emit("show_adb_status", "Set devtools.debugger.remote-enabled:true and manually accept incoming connection");  
+                    panel.port.emit("show_adb_status",
+                        "Set devtools.debugger.remote-enabled pref and " +
+                        "manually accept incoming connection. " +
+                        "To avoid conflict, only one running app can have this pref set.");
                     self.initProfiler(remoteProfilerFile.RemoteProfiler, options, function() {
                         panel.port.emit("show_panel", "Controls");
                     });
@@ -1910,6 +1913,9 @@ let FirefoxAppWrapper = {
               );
             },
             function error_cb(error) {
+              if (error.pkgs) {
+                panel.port.emit("show_packages", error.pkgs);
+              }
               panel.port.emit("show_log", error.description);
             },
             function progress_cb(info) {

--- a/lib/remoteHost.js
+++ b/lib/remoteHost.js
@@ -197,17 +197,28 @@ RemoteHost.prototype.updateApk = function RemoteHost_updateApk(srcApk, cb) {
 };
 
 // Make sure all the libraries are downloaded and update to date for symbolication.
-RemoteHost.prototype.prepareLibs = function RemoteHost_prepareLibs(cb, error_cb, progress_cb) {
+RemoteHost.prototype.prepareLibs = function RemoteHost_prepareLibs(pkg, cb, error_cb, progress_cb) {
   progress_cb({description: "Finding process"});
   var self = this;
   cmdRunnerModule.runCommand("/bin/bash -l -c 'adb shell ps'", function(r) {
+    function getPkg (line) {
+      var columns = line.trim().split(" ");
+      if (pkg) {
+        return columns[columns.length - 1] === pkg ? pkg : null;
+      }
+      var match = columns[columns.length - 1].match(/^org\.mozilla\.\w+$/);
+      return match && match[0];
+    }
     var lines = r.split("\n");
     var processLine = null;
     for (var i = 0; i < lines.length; i++) {
       var line = lines[i];
-      if (line.indexOf("org.mozilla.fennec") != -1) {
+      if (getPkg(line)) {
         if (processLine != null) {
-          error_cb({description: "You have more then one instance of Fennec running"});
+          error_cb({
+            description: "Choose target package name.",
+            pkgs: lines.map(getPkg).filter(function (elem) elem)
+          });
           return;
         }
         processLine = line;


### PR DESCRIPTION
A lot of times, when multiple Fennec packages are installed, the addon fails to connect because it doesn't know which of the running packages the target belongs to. This change allows the user to choose which package their target is when there is ambiguity.
