### PR TITLE
fix parsing adb devices to cope with tcp connections

### DIFF
--- a/lib/remoteHost.js
+++ b/lib/remoteHost.js
@@ -57,7 +57,7 @@ RemoteHost.prototype._fetchHardwareID = function RemoteHost__fetchHardwareID(cb)
     var connectedDevices = [];
     var lines = r.split("\n");
     for (var i = 0; i < lines.length; ++i) {
-      var line = lines[i].trim().split(/\W+/);
+      var line = lines[i].trim().split(/\s+/);
       if (line.length < 2 || line[1] != "device")
         continue;
       connectedDevices.push(line[0]);


### PR DESCRIPTION
when a device is connected with adb over TCP instead of USB
the output has IPADDR:PORT not serial# as the first column.

This fixes bug #56 
