### PR TITLE
Fix toolbar button ID, fixes issue #61

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1810,7 +1810,7 @@ let FirefoxAppWrapper = {
       });
       tbbOptions = {
         panel: panel,
-        id: "test-tbb",
+        id: "gecko-profiler-button",
         image: data.url("toolbar_on.png"),
         label: "Gecko Profiler",
         toolbarID: "nav-bar",


### PR DESCRIPTION
This will break the location of the button if people have customized it, but presumably they know how to put it back if they have. If they haven't customized it, this should just have it show up wherever it shows up by default (nav-bar).
