### PR TITLE
Update path to pathfinder (and fix error message)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,4 +9,4 @@ cd sdk
 git checkout firefox30
 mkdir packages
 cd packages
-git clone https://github.com/erikvold/addon-pathfinder
+git clone https://github.com/erikvold/pathfinder addon-pathfinder

--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-if [ ! -d "sdk" ]; then
-  echo "Must download the sdk first. See the INSTALLING for more info"
+if [ ! -d "sdk/packages/addon-pathfinder" ]; then
+  echo "Must download the sdk and pathfinder addon first. See bootstrap.sh or the README for more info"
   exit
 fi
 


### PR DESCRIPTION
`erikvold/addon-pathfinder` for whatever reason now points to `erikvold/addon-sdk`, and the repo we're looking for is at `erikvoid/pathfinder`. (To add to the confusion, `erikvold/addon-sdk` has a pathfinder branch)

Also fix the build.sh error message to check for both repos and point you to bootstrap.sh or README.

(Ideally these should be submodules)
