### PR TITLE
Remove unnecessary clipboard include

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -65,7 +65,6 @@ let remoteHost = require("remoteHost");
 var remoteHostInstance = null;
 let prefs = require("prefs");
 let data = require("sdk/self").data;
-let clipboard = require("sdk/clipboard");
 let timers = require("sdk/timers");
 let file = require("sdk/io/file");
 let tabs = null;


### PR DESCRIPTION
This throws an exception on Thunderbird, but appears to be unused. Combined with pull #76 and erikvold/pathfinder#1 this fixes Thunderbird (#75) \o/
