### PR TITLE
Improve bootstrap.sh.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,9 +4,19 @@ hash git 2> /dev/null || {
   exit -1
 }
 
-git clone https://github.com/mozilla/addon-sdk sdk
+if [ ! -d "sdk" ]; then
+  git clone https://github.com/mozilla/addon-sdk sdk
+fi
 cd sdk
+git fetch origin
 git checkout firefox30
-mkdir packages
+if [ ! -d "packages" ]; then
+  mkdir packages
+fi
 cd packages
-git clone https://github.com/erikvold/pathfinder addon-pathfinder
+if [ ! -d "addon-pathfinder" ]; then
+  git clone https://github.com/erikvold/pathfinder addon-pathfinder
+fi
+cd addon-pathfinder
+git fetch origin
+git checkout 4e6ec016b6c1d7f338b0e7b78b997766e7643d72


### PR DESCRIPTION
The script was failing if one of the directories existed already, and the current version of pathfinder is incompatible with our code (changed package name from pathfinder to addon-pathfinder) and incompatible with itself (removed addon/unload.js without fixing its own uses of it). So this checks out a known-to-work version of pathfinder instead.