### PR TITLE
Add Task Tracer support

### DIFF
--- a/src/data/settings.js
+++ b/src/data/settings.js
@@ -208,6 +208,7 @@ function selectTabSimple(mainAreaDiv) {
   var feature_stackwalking = addFeatureDiv(mainAreaDiv, "Stackwalk", "stackwalk", "");
   var feature_jank = addFeatureDiv(mainAreaDiv, "Jank", "jank", "");
   var feature_mainthreadio = addFeatureDiv(mainAreaDiv, "Main Thread I/O", "mainthreadio", "");
+  var feature_tasktracer = addFeatureDiv(mainAreaDiv, "Task Tracer", "tasktracer", "");
 }
 function selectTabAdvanced(mainAreaDiv) {
   var featuresDiv = document.createElement("div");

--- a/src/data/sps_panel.html
+++ b/src/data/sps_panel.html
@@ -116,6 +116,7 @@ table {
       <input id=chkGC type="checkbox"/> GC Stats<br>
       <input id=chkUnwinder type="checkbox"/> Breakpad
       <input id=chkMainthreadio type="checkbox"/> Main Thread I/O<br>
+      <input id=chkTaskTracer type="checkbox"/> Task Tracer<br>
       <input id=chkJava type="checkbox"/>Java (Android)<br>
       <input id=chkThreads type="checkbox"/> Multi-Thread
       ( <input id=txtThreadFilter type="text" placeholder="Filter e.g. Gecko,Web" size="15" title="Comma-separated list of thread name prefixes to profile"/> )<br>

--- a/src/data/sps_panel.js
+++ b/src/data/sps_panel.js
@@ -164,6 +164,15 @@ self.port.on("change_status", function(val) {
       }
     }
 
+    var chkTaskTracer = document.getElementById("chkTaskTracer");
+    if (chkTaskTracer) {
+      chkTaskTracer.disabled = !has_feature("tasktracer") || val.isActive;
+      chkTaskTracer.checked = val.isActive ? has_feature_active("tasktracer") : get_feature_pref("tasktracer");
+      chkTaskTracer.onclick = function() {
+        self.port.emit("set_feature", {feature: "tasktracer", value: chkTaskTracer.checked});
+      }
+    }
+
     var chkJava = document.getElementById("chkJava");
     if (chkJava) {
       chkJava.disabled = !has_feature("java") || val.isActive;

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -717,6 +717,8 @@ function sps_startup(force, manifest) {
     var want_feature_displaylistdump = prefs.get_pref_bool("profiler.", "displaylistdump", false);
     var want_feature_adb = prefs.get_pref_bool("profiler.", "adb", false);
     var want_feature_mainthreadio = prefs.get_pref_bool("profiler.", "mainthreadio", false);
+    var want_feature_tasktracer = prefs.get_pref_bool("profiler.", "tasktracer", false);
+
     threadFilter = prefs.get_pref_string('profiler.', 'threadfilter', 'GeckoMain,Compositor');
 
     if (manifest.defaultTestSettings) {
@@ -732,6 +734,7 @@ function sps_startup(force, manifest) {
       want_feature_displaylistdump = false;
       want_feature_adb = true;
       want_feature_mainthreadio = false;
+      want_feature_tasktracer = false;
       threadFilter = '';
     }
 
@@ -750,6 +753,7 @@ function sps_startup(force, manifest) {
     want_feature_displaylistdump = manifest.displaylistdump || want_feature_displaylistdump;
     want_feature_adb = manifest.adb || want_feature_adb;
     want_feature_mainthreadio = manifest.mainthreadio || want_feature_mainthreadio;
+    want_feature_tasktracer = manifest.tasktracer || want_feature_tasktracer;
     threadFilter = manifest.threadFilter || threadFilter;
 
     // Make sure we have enough entries to get results back
@@ -803,6 +807,10 @@ function sps_startup(force, manifest) {
     if (has_feature("mainthreadio") && want_feature_mainthreadio) {
         selectedFeatures.push("mainthreadio");
     }
+    if (has_feature("tasktracer") && want_feature_tasktracer) {
+        selectedFeatures.push("tasktracer");
+    }
+
     savedProfileLastStop = null; 
     DEBUGLOG("Start profiling with options:");
     DEBUGLOG(selectedFeatures);


### PR DESCRIPTION
If the underlying application supports using Task Tracer, the checkbox
will be enabled in the panel.